### PR TITLE
Expand notifications

### DIFF
--- a/src/configureAssistant.ts
+++ b/src/configureAssistant.ts
@@ -183,7 +183,7 @@ export class AiAssistantConfigurator {
       if (currentChatModel) {
         message += ` Now select '${currentChatModel}' from Continue's chat model dropdown.`;
       }
-      vscode.window.showInformationMessage(message);
+      vscode.window.showInformationMessage(message, "");
     }
 
     if (continueOnboardingMightShow) {


### PR DESCRIPTION
As @matthicksj noticed, the notifications are collapsed by default:
<img width="587" alt="Screenshot 2024-11-22 at 10 45 47" src="https://github.com/user-attachments/assets/74fd1136-73a0-440e-96d3-674db6820645">

Adding an empty action expands the notification by default:
<img width="567" alt="Screenshot 2024-11-22 at 11 13 40" src="https://github.com/user-attachments/assets/242e2f1c-4ac3-48cf-a6e7-08ddf0ee95a7">

 We can't use new lines in such notifications though.