### PR TITLE
Added scenario to handle enable/disable of setup button. Also button text changed based on the scenario that either setup/update

### DIFF
--- a/src/panels/setupGranitePage.ts
+++ b/src/panels/setupGranitePage.ts
@@ -360,6 +360,17 @@ export class SetupGranitePage {
         tabModel,
         embeddingsModel
       );
+
+      //set recent used models
+      webview.postMessage({
+        command: "recentModels",
+        data: {
+          recentChatModel: chatModel,
+          recentTabModel: tabModel,
+          recentEmbeddingModel: embeddingsModel
+        },
+      });
+
       console.log("Granite AI-Assistant setup complete");
       await Telemetry.send("paver.setup.success", {
         chatModelId: chatModel ?? 'none',
@@ -371,6 +382,17 @@ export class SetupGranitePage {
       if (error instanceof CancellationError || error?.name === "Canceled") {
         return;
       }
+
+      //set recent used models to null when error
+      webview.postMessage({
+        command: "recentModels",
+        data: {
+          recentChatModel: null,
+          recentTabModel: null,
+          recentEmbeddingModel: null
+        },
+      });
+
       // Generic error handling for all errors
       await Telemetry.send("paver.setup.error", {
         error: error?.message ?? 'unknown error',

--- a/webviews/src/App.tsx
+++ b/webviews/src/App.tsx
@@ -45,6 +45,12 @@ function App() {
 
   const [isKeepExistingConfigSelected, setIsKeepExistingConfigSelected] = useState(false);
 
+  const [buttonTitle, setButtonTitle] = useState('');
+
+  const [recentTabModel, setRecentTabModel] = useState<string | null>(null);
+  const [recentChatModel, setRecentChatModel] = useState<string | null>(null);
+  const [recentEmbeddingsModel, setRecentEmbeddingsModel] = useState<string | null>(null);
+
   const getModelStatus = useCallback((model: string | null): ModelStatus | null => {
     if (model === null) {
       return null;
@@ -85,6 +91,11 @@ function App() {
     });
   }
 
+  function handleSetupGraniteEnableDisable(): boolean {
+    return serverStatus === ServerStatus.started && chatModel === recentChatModel &&
+      embeddingsModel === recentEmbeddingsModel;
+  }
+
   const REFETCH_MODELS_INTERVAL_MS = 1500;
   let ollamaStatusChecker: NodeJS.Timeout | undefined;
 
@@ -122,6 +133,12 @@ function App() {
         setEnabled(!disabled);
         break;
       }
+      case 'recentModels': {
+        setRecentChatModel(payload.data.recentChatModel);
+        setRecentTabModel(payload.data.recentTabModel);
+        setRecentEmbeddingsModel(payload.data.recentEmbeddingModel);
+        break;
+      }
     }
   }, []);
 
@@ -154,6 +171,15 @@ function App() {
       }
     };
   }, [serverStatus, modelStatuses]);
+
+  useEffect(() => {
+    if (serverStatus === ServerStatus.started && ModelStatus.installed === getModelStatus(chatModel) &&
+      ModelStatus.installed === getModelStatus(embeddingsModel)) {
+      setButtonTitle('Update Granite');
+    } else {
+      setButtonTitle('Setup Granite');
+    }
+  }), [buttonTitle];
 
   const getServerIconType = useCallback((status: ServerStatus): StatusValue => {
     switch (status) {
@@ -272,8 +298,9 @@ function App() {
         />
 
         <div className="final-setup-group">
-          <button className="install-button" onClick={handleSetupGraniteClick} disabled={serverStatus !== ServerStatus.started || !enabled || isKeepExistingConfigSelected}>
-            Setup Granite
+          <button className="install-button" onClick={handleSetupGraniteClick}
+            disabled={handleSetupGraniteEnableDisable() || serverStatus !== ServerStatus.started}>
+            {buttonTitle}
           </button>
         </div>
       </div>


### PR DESCRIPTION
This PR helps to handle the below scenarios, and it would be nice to have as a user perspective.

1. Button text changed between Setup/Update based on the installation status of the models
2. If user selects the model which currently used then disabled the button

PFA

![disable-setup-btn](https://github.com/user-attachments/assets/5b287239-2c32-40d8-8c5a-518f2663a619)