### PR TITLE
added start Ollama button and it functionality

### DIFF
--- a/src/panels/setupGranitePage.ts
+++ b/src/panels/setupGranitePage.ts
@@ -18,6 +18,7 @@ import { IModelServer } from '../modelServer';
 import { MockServer } from '../ollama/mockServer';
 import { OllamaServer } from "../ollama/ollamaServer";
 import { Telemetry } from '../telemetry';
+import { terminalCommandRunner } from '../terminal/terminalCommandRunner';
 import { getNonce } from "../utils/getNonce";
 import { getUri } from "../utils/getUri";
 import { getSystemInfo } from "../utils/sysUtils";
@@ -239,6 +240,14 @@ export class SetupGranitePage {
               },
             });
             break;
+          case "startOllama":
+            await terminalCommandRunner.runInTerminal(
+              'ollama start',
+              {
+                name: "Start Ollama",
+                show: true,
+              }
+            );
           case "installOllama":
             await this.server.installServer(data.mode);
             break;

--- a/src/panels/setupGranitePage.ts
+++ b/src/panels/setupGranitePage.ts
@@ -18,7 +18,6 @@ import { IModelServer } from '../modelServer';
 import { MockServer } from '../ollama/mockServer';
 import { OllamaServer } from "../ollama/ollamaServer";
 import { Telemetry } from '../telemetry';
-import { terminalCommandRunner } from '../terminal/terminalCommandRunner';
 import { getNonce } from "../utils/getNonce";
 import { getUri } from "../utils/getUri";
 import { getSystemInfo } from "../utils/sysUtils";
@@ -241,13 +240,8 @@ export class SetupGranitePage {
             });
             break;
           case "startOllama":
-            await terminalCommandRunner.runInTerminal(
-              'ollama start',
-              {
-                name: "Start Ollama",
-                show: true,
-              }
-            );
+            await this.server.startServer();
+            break;
           case "installOllama":
             await this.server.installServer(data.mode);
             break;

--- a/src/terminal/terminalCommandRunner.ts
+++ b/src/terminal/terminalCommandRunner.ts
@@ -18,7 +18,7 @@ class TerminalCommandRunner implements Disposable {
     public async runInTerminal(command: string, options: ITerminalOptions): Promise<Terminal> {
 
         let terminal: Terminal | undefined;
-        const name = "Granite Models Setup";
+        const name = options.name;
         if (window.terminals.length) {
             terminal = window.terminals.find(t => name === t.name);
         }

--- a/webviews/src/App.tsx
+++ b/webviews/src/App.tsx
@@ -122,6 +122,12 @@ function App() {
     });
   }
 
+  function handleStartOllama(): void {
+    vscode.postMessage({
+      command: "startOllama"
+    });
+  }
+
   const REFETCH_MODELS_INTERVAL_MS = 1500;
   let ollamaStatusChecker: NodeJS.Timeout | undefined;
 
@@ -313,30 +319,36 @@ function App() {
             </label>
 
             {/* New section for additional buttons */}
-            {serverStatus === ServerStatus.missing &&
-              installationModes.length > 0 && (
-                <div className="install-options">
-                  {installationModes.some(
-                    (mode) => mode.supportsRefresh === true
-                  ) && (
-                      <p>
-                        <span>
-                          This page will refresh once Ollama is installed.
-                        </span>
-                      </p>
-                    )}
-                  {installationModes.map((mode) => (
-                    <button
-                      key={mode.id}
-                      className="install-button"
-                      onClick={() => handleInstallOllama(mode.id)}
-                      disabled={!enabled}
-                    >
-                      {mode.label}
-                    </button>
-                  ))}
-                </div>
-              )}
+            {serverStatus === ServerStatus.missing && installationModes.length > 0 && (
+              <div className="install-options">
+                {installationModes.some(mode => mode.supportsRefresh === true) && (
+                  <p><span>This page will refresh once Ollama is installed.</span></p>
+                )}
+                {installationModes.map((mode) => (
+                  <button
+                    key={mode.id}
+                    className="install-button"
+                    onClick={() => handleInstallOllama(mode.id)}
+                    disabled={!enabled}
+                  >
+                    {mode.label}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {
+              // show start ollama button when server stopped
+              serverStatus === ServerStatus.stopped && (
+                <button
+                  className="install-button"
+                  onClick={() => handleStartOllama()}
+                >
+                  Start Ollama
+                </button>
+              )
+            }
+
           </div>
         </div>
         {(diskSpaceCheck.warnings.length > 0 || diskSpaceCheck.errors.length > 0) && (


### PR DESCRIPTION
This PR shows `Start Ollama` button when `Ollama` server was stopped. When user clicks the button it starts the server on terminal

![add-start-ollama-btn](https://github.com/user-attachments/assets/f848b8b1-ba02-435f-8391-fbfdfbc152cd)
