### PR TITLE
Update models to granite3.1-*

### DIFF
--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -1,4 +1,2 @@
 export const EXTENSION_ID = 'redhat.vscode-paver';
 export const isDevMode = process.env.PAVER_EXT_DEV_MODE === 'true';
-export const DOWNLOADABLE_MODELS = ['nomic-embed-text:latest', 'granite-code:3b', 'granite-code:8b', 'granite3-dense:2b', 'granite3-dense:8b'];
-

--- a/src/commons/modelInfo.ts
+++ b/src/commons/modelInfo.ts
@@ -5,12 +5,12 @@ export const DEFAULT_MODEL_INFO = new Map<string, ModelInfo>();
   digest: ''
 },
 {
-  id: 'granite3-dense:2b',
-  size: '1.6GB',
+  id: 'granite3.1-dense:2b',
+  size: '1.5GB',
   digest: ''
 },
 {
-  id: 'granite3-dense:8b',
+  id: 'granite3.1-dense:8b',
   size: '4.9GB',
   digest: ''
 },

--- a/src/commons/modelRequirements.ts
+++ b/src/commons/modelRequirements.ts
@@ -10,13 +10,13 @@ export interface ModelRequirements {
 }
 
 export const MODEL_REQUIREMENTS: Record<string, ModelRequirements> = {
-  "granite3-dense:2b": {
+  "granite3.1-dense:2b": {
     minMemoryBytes: 4 * GB,
     recommendedMemoryBytes: 8 * GB,
     gpuRecommended: false,
-    sizeBytes: Math.ceil(1.6 * GB)
+    sizeBytes: Math.ceil(1.5 * GB)
   },
-  "granite3-dense:8b": {
+  "granite3.1-dense:8b": {
     minMemoryBytes: 12 * GB,
     recommendedMemoryBytes: 16 * GB,
     gpuRecommended: true,
@@ -41,6 +41,8 @@ export const MODEL_REQUIREMENTS: Record<string, ModelRequirements> = {
     sizeBytes: Math.ceil(0.274 * GB)
   }
 };
+
+export const DOWNLOADABLE_MODELS = Object.keys(MODEL_REQUIREMENTS);
 
 interface ValidationResult {
   isCompatible: boolean;

--- a/src/commons/sysInfo.ts
+++ b/src/commons/sysInfo.ts
@@ -59,8 +59,8 @@ export function hasDiscreteGPU(gpus: GpuInfo[]): boolean {
 
 export function getRecommendedModels(systemInfo: SystemInfo) {
   const defaultGraniteModel = isHighEndMachine(systemInfo)
-    ? "granite3-dense:8b"    // 8B for powerful systems
-    : "granite3-dense:2b";   // 2B for others
+    ? "granite3.1-dense:8b"    // 8B for powerful systems
+    : "granite3.1-dense:2b";   // 2B for others
 
   return {
     defaultChatModel: defaultGraniteModel,

--- a/src/configureAssistant.ts
+++ b/src/configureAssistant.ts
@@ -36,7 +36,7 @@ export interface AiAssistantConfigurationRequest {
   embeddingsModel: string | null;
 }
 
-const DEFAULT_CONTEXT_LENGTH = 4096;
+const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_API_BASE = "http://localhost:11434";
 const DEFAULT_PROVIDER = "ollama";
 
@@ -52,7 +52,7 @@ const baseGraniteConfig: Partial<ModelConfig> = {
   ...baseConfig,
   contextLength: DEFAULT_CONTEXT_LENGTH,
   completionOptions: {
-    maxTokens: DEFAULT_CONTEXT_LENGTH / 2,
+    maxTokens: DEFAULT_CONTEXT_LENGTH / 4,
     temperature: 0,
     topP: 0.9,
     topK: 40,
@@ -74,11 +74,11 @@ const modelConfigs: ModelConfig[] = [
     contextLength: 128000,
   },
   {
-    model: "granite3-dense:2b",
+    model: "granite3.1-dense:2b",
     ...baseGraniteConfig,
   },
   {
-    model: "granite3-dense:8b",
+    model: "granite3.1-dense:8b",
     ...baseGraniteConfig,
   },
   {

--- a/src/panels/setupGranitePage.ts
+++ b/src/panels/setupGranitePage.ts
@@ -11,7 +11,8 @@ import {
   WebviewPanel,
   window
 } from "vscode";
-import { DOWNLOADABLE_MODELS, isDevMode } from '../commons/constants';
+import { isDevMode } from '../commons/constants';
+import { DOWNLOADABLE_MODELS } from '../commons/modelRequirements';
 import { ProgressData } from "../commons/progressData";
 import { ModelStatus, ServerStatus } from '../commons/statuses';
 import { IModelServer } from '../modelServer';

--- a/webviews/src/App.test.tsx
+++ b/webviews/src/App.test.tsx
@@ -81,8 +81,8 @@ describe("App Component", () => {
     expect(mockPostMessage).toHaveBeenCalledWith({
       command: "setupGranite",
       data: {
-        chatModelId: "granite3-dense:2b",
-        tabModelId: "granite3-dense:2b",
+        chatModelId: "granite3.1-dense:2b",
+        tabModelId: "granite3.1-dense:2b",
         embeddingsModelId: "nomic-embed-text:latest",
       },
     });
@@ -162,8 +162,8 @@ describe("App Component", () => {
     expect(mockPostMessage).toHaveBeenCalledWith({
       command: "setupGranite",
       data: {
-        chatModelId: "granite3-dense:2b",
-        tabModelId: "granite3-dense:2b",
+        chatModelId: "granite3.1-dense:2b",
+        tabModelId: "granite3.1-dense:2b",
         embeddingsModelId: "nomic-embed-text:latest",
       },
     });

--- a/webviews/src/App.tsx
+++ b/webviews/src/App.tsx
@@ -14,14 +14,14 @@ import { getRecommendedModels } from "../../src/commons/sysInfo";
 function App() {
   const modelOptions: ModelOption[] = [
     {
-      label: "granite3-dense:2b",
-      value: "granite3-dense:2b",
-      info: formatSize(MODEL_REQUIREMENTS["granite3-dense:2b"].sizeBytes)
+      label: "granite3.1-dense:2b",
+      value: "granite3.1-dense:2b",
+      info: formatSize(MODEL_REQUIREMENTS["granite3.1-dense:2b"].sizeBytes)
     },
     {
-      label: "granite3-dense:8b",
-      value: "granite3-dense:8b",
-      info: formatSize(MODEL_REQUIREMENTS["granite3-dense:8b"].sizeBytes)
+      label: "granite3.1-dense:8b",
+      value: "granite3.1-dense:8b",
+      info: formatSize(MODEL_REQUIREMENTS["granite3.1-dense:8b"].sizeBytes)
     },
     {
       label: "granite-code:3b",


### PR DESCRIPTION
Update models to granite3.1-dense:2b and :8b, with context length extended to 128k